### PR TITLE
Add website name and icon url for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,22 @@
 			fmt.Println(err)
 			return
 		}
+		fmt.Printf("Icon : %s\n", s.Preview.Icon)
+		fmt.Printf("Name : %s\n", s.Preview.Name)
 		fmt.Printf("Title : %s\n", s.Preview.Title)
 		fmt.Printf("Description : %s\n", s.Preview.Description)
 		fmt.Printf("Image: %s\n", s.Preview.Images[0])
 		fmt.Printf("Url : %s\n", s.Preview.Link)
 	}
 
-output: 
+output:
 
+**Icon :** https://www.w3.org/favicon.ico  
+**Name :** www.w3.org  
 **Title :** World Wide Web Consortium (W3C)  
 **Description :** The World Wide Web Consortium (W3C) is an international community where Member organizations, a full-time staff, and the public work together to develop Web standards.  
 **Image:** https://www.w3.org/2008/site/images/logo-w3c-mobile-lg  
-**Url :** https://www.w3.org/  
+**Url :** https://www.w3.org/
 
 
 ## License


### PR DESCRIPTION
Add more information from getting url.  
Like `slack` message:
![Imgur](https://i.imgur.com/yKtcOmI.png)

We need the following data to render the result :)

**1. Icon**
**2. Website Name**
3. Title
4. Description
5. Image
6. Url

```
Icon : https://assets-cdn.github.com/favicon.ico
Name : GitHub
Title : chenyunchen - Overview
Description : Freelancer, Full Stack Web Developer. Love Golang. - chenyunchen
Image: https://avatars3.githubusercontent.com/u/5100757?s=400&v=4
Url : https://github.com/chenyunchen
```