### PR TITLE
fix: icon links are no only with exact rel="ico"

### DIFF
--- a/goscraper.go
+++ b/goscraper.go
@@ -197,7 +197,7 @@ func (scraper *Scraper) parseDocument(doc *Document) error {
 				if cleanStr(attr.Key) == "rel" && cleanStr(attr.Val) == "canonical" {
 					canonical = true
 				}
-				if cleanStr(attr.Key) == "rel" && cleanStr(attr.Val) == "icon" {
+				if cleanStr(attr.Key) == "rel" && strings.Contains(cleanStr(attr.Val),  "icon") {
 					hasIcon = true
 				}
 				if cleanStr(attr.Key) == "href" {


### PR DESCRIPTION
Some pages now have icons in links with `rel="shortcut icon"` for example, actually only when `rel` is exactly equal to `icon` the app is extracting it.