### PR TITLE
Fixes stop redirect to login pages and fix meta fetch condition

### DIFF
--- a/goscraper.go
+++ b/goscraper.go
@@ -23,6 +23,7 @@ type Scraper struct {
 	Url                *url.URL
 	EscapedFragmentUrl *url.URL
 	MaxRedirect        int
+	UserAgent          string
 }
 
 type Document struct {
@@ -39,12 +40,15 @@ type DocumentPreview struct {
 	Link        string
 }
 
-func Scrape(uri string, maxRedirect int) (*Document, error) {
+func Scrape(uri string, maxRedirect int, userAgent string) (*Document, error) {
+	if userAgent == "" {
+		userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+	}
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
 	}
-	return (&Scraper{Url: u, MaxRedirect: maxRedirect}).Scrape()
+	return (&Scraper{Url: u, MaxRedirect: maxRedirect, UserAgent: userAgent}).Scrape()
 }
 
 func (scraper *Scraper) Scrape() (*Document, error) {
@@ -135,7 +139,7 @@ func (scraper *Scraper) getDocument() (*Document, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("User-Agent", "GoScraper")
+	req.Header.Add("User-Agent", scraper.UserAgent)
 
 	resp, err := scraper.client().Do(req)
 	if resp != nil {

--- a/goscraper.go
+++ b/goscraper.go
@@ -23,7 +23,7 @@ type Scraper struct {
 	Url                *url.URL
 	EscapedFragmentUrl *url.URL
 	MaxRedirect        int
-	UserAgent          string
+	Headers            map[string]string
 }
 
 type Document struct {
@@ -40,15 +40,12 @@ type DocumentPreview struct {
 	Link        string
 }
 
-func Scrape(uri string, maxRedirect int, userAgent string) (*Document, error) {
-	if userAgent == "" {
-		userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
-	}
+func Scrape(uri string, maxRedirect int, headers map[string]string) (*Document, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
 	}
-	return (&Scraper{Url: u, MaxRedirect: maxRedirect, UserAgent: userAgent}).Scrape()
+	return (&Scraper{Url: u, MaxRedirect: maxRedirect, Headers: headers}).Scrape()
 }
 
 func (scraper *Scraper) Scrape() (*Document, error) {
@@ -139,7 +136,10 @@ func (scraper *Scraper) getDocument() (*Document, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("User-Agent", scraper.UserAgent)
+	//Add headers
+	for k, v := range scraper.Headers {
+		req.Header.Add(k, v)
+	}
 
 	resp, err := scraper.client().Do(req)
 	if resp != nil {


### PR DESCRIPTION
1-Fix meta data scraping ex: https://www.meetup.com/Berlinstartups/
2-Added check redirect middleware  to prevent url like this from redirect to login
https://www.meetup.com/Berlinstartups/?_xtd=gqFyqTIzNjg1ODg3M6Fwp2FuZHJvaWQ&from=ref