### PR TITLE
Add MaxDocumentLength and custom UserAgent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,105 @@
+# Created by .ignore support plugin (hsz.mobi)
+### VisualStudioCode template
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+.idea
+
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Go template
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+tests/

--- a/goscraper.go
+++ b/goscraper.go
@@ -31,14 +31,14 @@ type ScrapeBuilder interface {
 	SetMaxDocumentLength(int64) ScrapeBuilder
 	SetUrl(string) ScrapeBuilder
 	SetMaxRedirect(int) ScrapeBuilder
-	Build() (*Scraper, error)
+	Build() (ScrapeService, error)
 }
 
 type scrapeBuilder struct {
 	scrapeSettings scrapeSettings
 }
 
-func (b *scrapeBuilder) Build() (*Scraper, error) {
+func (b *scrapeBuilder) Build() (ScrapeService, error) {
 	u, err := url.Parse(b.scrapeSettings.url)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,9 @@ func (b *scrapeBuilder) SetUserAgent(s string) ScrapeBuilder {
 }
 
 func NewScrapeBuilder() ScrapeBuilder {
-	return &scrapeBuilder{scrapeSettings{userAgent: "GoScraper"}}
+	return &scrapeBuilder{
+		scrapeSettings: scrapeSettings{userAgent: "GoScraper"},
+	}
 }
 
 type ScraperOptions struct {
@@ -106,6 +108,12 @@ type DocumentPreview struct {
 	Type        string
 	Images      []string
 	Link        string
+}
+
+type ScrapeService interface {
+	Scrape() (*Document, error)
+	GetDocument() (*Document, error)
+	ParseDocument(doc *Document) (*Document, error)
 }
 
 func Scrape(uri string, maxRedirect int, options ScraperOptions) (*Document, error) {

--- a/goscraper.go
+++ b/goscraper.go
@@ -382,10 +382,8 @@ func (scraper *Scraper) parseDocument(doc *Document) error {
 					return err
 				}
 				if !ogImgUrl.IsAbs() {
-					ogImgUrl, err = url.Parse(fmt.Sprintf("%s://%s%s", scraper.Url.Scheme, scraper.Url.Host, ogImgUrl.Path))
-					if err != nil {
-						return err
-					}
+					ogImgUrl.Host = scraper.Url.Host
+					ogImgUrl.Scheme = scraper.Url.Scheme
 				}
 
 				doc.Preview.Images = []string{ogImgUrl.String()}


### PR DESCRIPTION
Due to the reason that sometimes URLs can be to some pages/files that are a pretty big one - we want to be able to abort the reading body for those pages. 
